### PR TITLE
Fix sensitivity to background edges of lbpExtract

### DIFF
--- a/lbpExtract/app/conf/config.ini
+++ b/lbpExtract/app/conf/config.ini
@@ -5,3 +5,4 @@ topBound        40
 minArcLength    75
 maxArcLength    400
 numIteration    5
+minWidth        3

--- a/lbpExtract/include/lbpExtract.h
+++ b/lbpExtract/include/lbpExtract.h
@@ -71,6 +71,7 @@ private:
     int     numIteration, defaultNumIteration;
     int     minArea, defaultMinArea;
     int     maxArea, defaultMaxArea;
+    int     minWidth, defaultMinWidth;
     int     bbOffset;
     bool    verbose;
     
@@ -96,7 +97,7 @@ public:
     void    onRead( yarp::sig::ImageOf<yarp::sig::PixelRgb> &img );
     void    interrupt();
     
-    bool setDefaultValues(const int32_t radius, const int32_t neighbours, const int32_t topBound, const int32_t minArcLength, const int32_t maxArcLength, const int32_t numIteration, const int32_t minArea, const int32_t maxArea );
+    bool setDefaultValues(const int32_t radius, const int32_t neighbours, const int32_t topBound, const int32_t minArcLength, const int32_t maxArcLength, const int32_t numIteration, const int32_t minArea, const int32_t maxArea, const int32_t minWidth );
     
     bool setRadius(const int32_t radius);
     bool setNeighbours(const int32_t neighbours);
@@ -106,6 +107,7 @@ public:
     bool setNumIteration(const int32_t numIteration);
     bool setMinArea(const int32_t minArea);
     bool setMaxArea(const int32_t maxArea);
+    bool setMinWidth(const int32_t minWidth);
     bool setbbOffset(const int32_t offset);
     bool resetAllValues();
     bool verbosity(const int32_t boolVerbosity);
@@ -117,6 +119,7 @@ public:
     int32_t getMaxArcLength();
     int32_t getMinArea();
     int32_t getMaxArea();
+    int32_t getMinWidth();
     int32_t getNumIteration();
     int32_t getbbOffset();
     yarp::os::Bottle get_component_around(const int32_t x, const int32_t y);
@@ -153,6 +156,7 @@ public:
     bool setNumIteration(const int32_t numIteration);
     bool setMinArea(const int32_t minArea);
     bool setMaxArea(const int32_t maxArea);
+    bool setMinWidth(const int32_t minWidth);
     bool resetAllValues();
     bool verbosity(const int32_t boolVerbosity);
     bool setbbOffset(const int32_t offset);
@@ -164,6 +168,7 @@ public:
     int32_t getMaxArcLength();
     int32_t getMinArea();
     int32_t getMaxArea();
+    int32_t getMinWidth();
     int32_t getNumIteration();
     int32_t getbbOffset();
     yarp::os::Bottle get_component_around(const int32_t x, const int32_t y);

--- a/lbpExtract/lbpExtract.thrift
+++ b/lbpExtract/lbpExtract.thrift
@@ -119,6 +119,19 @@ service lbpExtract_IDLServer
     bool setMinArea(1:i32 minArea);
 
     /**
+     * Gets the minimum width of the linear elements of the allowed blobs
+     * @return the current minimum width
+     **/
+    i32 getMinWidth();
+
+    /**
+     * Sets the minimum width of the linear elements of the allowed blobs
+     * @param minWidth, integer containing the minWidth
+     * @return true/false on success/failure
+     **/
+    bool setMinWidth(1:i32 minWidth);
+
+    /**
      * Gets the number of iteration for the grabCut segmentation algorithm
      * @return the current maximum arc length
      **/

--- a/lbpExtract/lbpExtract.xml
+++ b/lbpExtract/lbpExtract.xml
@@ -25,6 +25,7 @@
    <param default="400" desc="To specify the maximum arc length of the allowed blobs">maxArcLength</param>
    <param default="1000" desc="To specify the minimum area of the allowed blobs">minArea</param>
    <param default="3000" desc="To specify the maximum area of the allowed blobs">maxArea</param>
+   <param default="3" desc="To specify the minimum width of the linear element of the allowed blobs">minWidth</param>
    </arguments>
 
    <authors>

--- a/lbpExtract/src/lbpExtract.cpp
+++ b/lbpExtract/src/lbpExtract.cpp
@@ -50,8 +50,9 @@ bool SEGMENTModule::configure(yarp::os::ResourceFinder &rf){
     int maxL    = rf.check("maxArcLength",yarp::os::Value(1000)).asInt();
     int minA    = rf.check("minArea",yarp::os::Value(300)).asInt();
     int maxA    = rf.check("maxArea",yarp::os::Value(6000)).asInt();
+    int minW    = rf.check("minWidth",yarp::os::Value(3)).asInt();
 
-    segmentManager->setDefaultValues(rad, neigh, topB, minL, maxL, iter, minA, maxA);
+    segmentManager->setDefaultValues(rad, neigh, topB, minL, maxL, iter, minA, maxA, minW);
 
     /* now start the thread to do the work */
     segmentManager->open();
@@ -147,6 +148,12 @@ bool SEGMENTModule::setMaxArea(const int32_t maxArea){
 }
 
 /**********************************************************/
+bool SEGMENTModule::setMinWidth(const int32_t minWidth){
+    segmentManager->setMinWidth(minWidth);
+    return true;
+}
+
+/**********************************************************/
 bool SEGMENTModule::setNumIteration(const int32_t numIteration){
     segmentManager->setNumIteration(numIteration);
     return true;
@@ -214,6 +221,11 @@ int SEGMENTModule::getMaxArea(){
 }
 
 /**********************************************************/
+int SEGMENTModule::getMinWidth(){
+    return segmentManager->getMinWidth();
+}
+
+/**********************************************************/
 int SEGMENTModule::getNumIteration(){
     return segmentManager->getNumIteration();
 }
@@ -240,7 +252,7 @@ SEGMENTManager::SEGMENTManager( const std::string &moduleName ){
 }
 
 /**********************************************************/
-bool SEGMENTManager::setDefaultValues(const int32_t radius, const int32_t neighbours, const int32_t topBound, const int32_t minArcLength, const int32_t maxArcLength, const int32_t numIteration, const int32_t minArea, const int32_t maxArea){
+bool SEGMENTManager::setDefaultValues(const int32_t radius, const int32_t neighbours, const int32_t topBound, const int32_t minArcLength, const int32_t maxArcLength, const int32_t numIteration, const int32_t minArea, const int32_t maxArea, const int32_t minWidth){
 
     defaultRadius       = radius;
     defaultNeighbours   = neighbours;
@@ -250,6 +262,7 @@ bool SEGMENTManager::setDefaultValues(const int32_t radius, const int32_t neighb
     defaultNumIteration = numIteration;
     defaultMinArea      = minArea;
     defaultMaxArea      = maxArea;
+    defaultMinWidth     = minWidth;
 
     return true;
 }
@@ -278,12 +291,14 @@ bool SEGMENTManager::open(){
 
     minArea = defaultMinArea;
     maxArea = defaultMaxArea;
-    
+
+    minWidth = defaultMinWidth;
+
     bbOffset = 0;
 
     verbose = false;
 
-    yInfo("Module started with the following default values:\nradius: %d, neighbours %d, minArcLength %d, maxArcLength, %d, minArea %d, maxArea, %d, topBound %d, numIteration %d", radius, neighbours, minArcLength, maxArcLength, minArea, maxArea, topBound, numIteration);
+    yInfo("Module started with the following default values:\nradius: %d, neighbours %d, minArcLength %d, maxArcLength %d, minArea %d, maxArea %d, minWidth %d, topBound %d, numIteration %d", radius, neighbours, minArcLength, maxArcLength, minArea, maxArea, minWidth, topBound, numIteration);
 
     return true;
 }
@@ -357,6 +372,12 @@ bool SEGMENTManager::setMaxArea(const int32_t maxArea){
 }
 
 /**********************************************************/
+bool SEGMENTManager::setMinWidth(const int32_t minWidth){
+    this->minWidth = minWidth;
+    return true;
+}
+
+/**********************************************************/
 bool SEGMENTManager::setNumIteration(const int32_t numIteration){
     this->numIteration = numIteration;
     return true;
@@ -377,6 +398,7 @@ bool SEGMENTManager::resetAllValues(){
     maxArcLength = defaultMaxArcLength;
     minArea = defaultMinArea;
     maxArea = defaultMaxArea;
+    minWidth = defaultMinWidth;
     bbOffset = 0;
     return true;
 }
@@ -421,6 +443,11 @@ int SEGMENTManager::getMinArea(){
 /**********************************************************/
 int SEGMENTManager::getMaxArea(){
     return this->maxArea;
+}
+
+/**********************************************************/
+int SEGMENTManager::getMinWidth(){
+    return this->minWidth;
 }
 
 /**********************************************************/
@@ -551,7 +578,25 @@ void SEGMENTManager::onRead(ImageOf<yarp::sig::PixelRgb> &img){
     cv::Mat structuringElement = cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(3, 3));
     cv::morphologyEx( cleanedImg, cleanedImg, cv::MORPH_CLOSE, structuringElement );
 
-    // Find contours
+    // Find contours and trim blobs according to radius size
+    if(radius > 1)
+    {
+        findContours( cleanedImg, cnt, hrch, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_TC89_L1 );
+        cv::fillPoly( cleanedImg, cnt, 255);
+        structuringElement = cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(2*radius-1, 2*radius-1));
+        cv::morphologyEx( cleanedImg, cleanedImg, cv::MORPH_ERODE, structuringElement );
+    }
+
+    // Find new clean contours and further remove parts that are too thin
+    if(minWidth > 0)
+    {
+        findContours( cleanedImg, cnt, hrch, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_TC89_L1 );
+        cv::fillPoly( cleanedImg, cnt, 255);
+        structuringElement = cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(minWidth, minWidth));
+        cv::morphologyEx( cleanedImg, cleanedImg, cv::MORPH_OPEN, structuringElement );
+    }
+
+    // Find final clean contours
     findContours( cleanedImg, cnt, hrch, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_TC89_L1 );
 
     // Align contours with initial image
@@ -691,39 +736,39 @@ void SEGMENTManager::onRead(ImageOf<yarp::sig::PixelRgb> &img){
             boundRectSeg[i] = boundingRect( cv::Mat(contours_polySeg[i]) );
 
             yarp::os::Bottle &t=b.addList();
-            
+
             if (bbOffset < 0)
                 bbOffset = 0;
-            
+
             double topLeftX = boundRectSeg[i].tl().x - bbOffset;
             double topLeftY = boundRectSeg[i].tl().y - bbOffset;
             double bottomRightX = boundRectSeg[i].br().x + bbOffset;
             double bottomRightY = boundRectSeg[i].br().y + bbOffset;
 
             yDebug("%lf %lf %lf %lf \n", topLeftX, topLeftY,  bottomRightX,  bottomRightY);
-        
+
             int shift = 3;
-            
+
             if (topLeftX < shift)
                 topLeftX = shift;
-            
+
             if (topLeftY < shift)
                 topLeftY = shift;
-            
+
             if (bottomRightX > img.width()-3)
                 bottomRightX = img.width()-3;
-            
+
             if (bottomRightY > img.height()-3)
                 bottomRightY = img.height()-3;
-            
+
             t.addDouble(topLeftX);
             t.addDouble(topLeftY);
             t.addDouble(bottomRightX);
             t.addDouble(bottomRightY);
-            
+
             /*cv::Point tl = cv::Point( (topLeftX), (topLeftY) );
             cv::Point br = cv::Point( (bottomRightX), (bottomRightY) );
-            
+
             line(segmented, cv::Point( tl.x, tl.y ), cv::Point( br.x, tl.y ),cv::Scalar(255,255,255), 1, 8);
             line(segmented, cv::Point( br.x, tl.y ), cv::Point( br.x, br.y ),cv::Scalar(255,255,255), 1, 8);
             line(segmented, cv::Point( br.x, br.y ), cv::Point( tl.x, br.y ),cv::Scalar(255,255,255), 1, 8);

--- a/lbpExtract/src/lbpExtract.cpp
+++ b/lbpExtract/src/lbpExtract.cpp
@@ -554,6 +554,18 @@ void SEGMENTManager::onRead(ImageOf<yarp::sig::PixelRgb> &img){
     // Find contours
     findContours( cleanedImg, cnt, hrch, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_TC89_L1 );
 
+    // Align contours with initial image
+    int alignOffsetX = (imgMat.cols - cleanedImg.cols) / 2;
+    int alignOffsetY = (imgMat.rows - cleanedImg.rows) / 2;
+    for( size_t i = 0; i < cnt.size(); i++ )
+    {
+        for( size_t j = 0; j < cnt[i].size(); j++ )
+        {
+            cnt[i][j].x += alignOffsetX;
+            cnt[i][j].y += alignOffsetY;
+        }
+    }
+
     // Get the moments
     std::vector<cv::Moments> mu(cnt.size() );
     for( size_t i = 0; i < cnt.size(); i++ )


### PR DESCRIPTION
This PR fixes the sensitivity of lbpExtract to background edges that crosses the objects.

It adds three things before the grabCut algorithm:

- fix a misalignment of the segmented contours.
- add an erosion step with a size proportional to the radius used for the VARLBP, so that the segmented contours are closer to the real contours instead of an enlarged version.
- add an opening step to remove small features present in the segmented object, typically thin lines from the background passing behind the object.
A new parameter called 'minWidth' is added to the interface to tune the size of this opening step.
